### PR TITLE
Switch to versioned Quark files.

### DIFF
--- a/examples/market/ratings/ratings.q
+++ b/examples/market/ratings/ratings.q
@@ -1,6 +1,6 @@
 package ratings 0.0.1;
 
-use ../../../datawire_connect.q;
+use ../../../quark/datawire_connect-1.0.0.q;
 
 import datawire_connect.resolver;
 import builtin.concurrent;

--- a/quark/datawire_connect-1.0.0.q
+++ b/quark/datawire_connect-1.0.0.q
@@ -1,7 +1,7 @@
 // We rely on the Discovery Service.
-use https://raw.githubusercontent.com/datawire/discovery/flynn/feature/discoball/discovery.q;
+use https://raw.githubusercontent.com/datawire/discovery/master/quark/discovery-1.0.0.q;
 
-import discovery;
+import datawire_discovery;
 
 namespace datawire_connect {
   namespace resolver {


### PR DESCRIPTION
Also reflect the change from `discovery` to `datawire_discovery`.
