### PR TITLE
Initial support for access to Datawire Connect state in Quark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+VERSION=$(shell cat VERSION)
+
+TESTGOLDFILE=$(shell echo /tmp/CloudTools-GOLD.$$PPID)
+
+all: init quark test
+
+.ALWAYS:
+
+init:
+	@if [ -z "$$VIRTUAL_ENV" ]; then echo "You must be in a venv for this"; false; fi
+	pip install -r requirements.txt
+
+quark: .ALWAYS
+	quark install quark/datawire_connect-1.0.0.q
+
+test: quark node_modules run-local-tests
+	-rm -f $(TESTGOLDFILE)
+
+run-local-tests:
+	nosetests test
+	python test/testDWState.py > $(TESTGOLDFILE)
+	node test/testDWState.js $(TESTGOLDFILE)
+	(cd test && mvn -q test -DGoldPath=$(TESTGOLDFILE))
+
+clean:
+	-find . -iname '*.pyc' -print0 | xargs -0 rm -f
+	-rm -rf test/target
+	
+clobber: clean
+	# Empty node_modules, but don't delete it (it has a .gitignore)
+	-rm -rf node_modules/*

--- a/quark/_datawire_fs_impl.js
+++ b/quark/_datawire_fs_impl.js
@@ -1,0 +1,30 @@
+(function () {
+    "use strict";
+
+    var os = require('os');
+    var fs = require('fs');
+
+    var quark = require('quark').quark;
+
+    var _datawire_fs = (function () {
+        function _datawire_fs() {}
+
+        _datawire_fs.userHomeDir = function () {
+            return os.homedir();
+        };
+
+        _datawire_fs.fileContents = function (path) {
+            try {
+                return fs.readFileSync(path, 'utf-8');
+            }
+            catch (e) {
+                var runtime = quark.concurrent.Context.runtime();
+                runtime.fail("failure reading " + path + ": " + e)
+            }
+        };
+
+        return _datawire_fs;
+    })();
+
+    module.exports = _datawire_fs;
+})();

--- a/quark/_datawire_fs_impl.py
+++ b/quark/_datawire_fs_impl.py
@@ -1,0 +1,21 @@
+__version__ = '1.0.0';
+
+import os
+
+import quark
+
+__all__ = """_datawire_fs""".split(' ')
+
+class _datawire_fs (object):
+    @classmethod
+    def userHomeDir(klass):
+        return os.path.expanduser('~')
+
+    @classmethod
+    def fileContents(klass, path):
+        try:
+            inputFile = open(path, "r")
+            return inputFile.read()
+        except Exception as e:
+            runtime = quark.concurrent.Context.runtime()
+            runtime.fail("failure reading %s: %s" % (path, e))

--- a/quark/datawire_connect-1.0.0.q
+++ b/quark/datawire_connect-1.0.0.q
@@ -3,7 +3,222 @@ use https://raw.githubusercontent.com/datawire/discovery/master/quark/discovery-
 
 import datawire_discovery;
 
+include _datawire_fs_impl.py;
+include _datawire_fs_impl.js;
+include io/datawire/quark/_datawire_fs_impl.java;
+
+// WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+//
+// DO NOT RELY ON THE NAME _datawire_fs TOO MUCH. IT IS ABOUT TO MOVE
+// INTO QUARK ITSELF.
+//
+// WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+
+namespace _datawire_fs {
+  macro String dwfs_userHomeDir()
+    $py{__import__('_datawire_fs_impl')._datawire_fs.userHomeDir()}
+    $js{require('datawire_connect_1_0_0/_datawire_fs_impl.js').userHomeDir()}
+    $java{io.datawire.quark.runtime._datawire_fs_impl.userHomeDir()};
+
+  macro String dwfs_fileContents(String path)
+    $py{__import__('_datawire_fs_impl')._datawire_fs.fileContents($path)}
+    $js{require('datawire_connect_1_0_0/_datawire_fs_impl.js').fileContents($path)}
+    $java{io.datawire.quark.runtime._datawire_fs_impl.fileContents($path)};
+
+  class FS {
+    static String userHomeDir() {
+      return dwfs_userHomeDir();
+    }
+
+    static String fileContents(String path) {
+      return dwfs_fileContents(path);
+    }        
+  }
+}
+
 namespace datawire_connect {
+
+  namespace state {
+    class DatawireState {
+      bool _initialized;
+      Runtime runtime;
+
+      JSONObject object;
+      JSONObject orgs;
+
+      /*
+       * _defaultOrg reflects the 'orgID' element saved in the state
+       * dictionary itself.
+       *
+       * _currentOrg reflects the org named by the 'switchToOrg' method.
+       *
+       * The two start out the same, but the current org can be switched.
+       */
+
+      String _defaultOrgID;
+      JSONObject _defaultOrg;
+
+      String _currentOrgID;
+      JSONObject _currentOrg;
+
+      @doc("DatawireState.defaultState() is the normal entry point.")
+      static DatawireState defaultState() {
+        DatawireState dwState = new DatawireState();
+
+        dwState.loadDefaultState();
+
+        return dwState;
+      }
+
+      @doc("DatawireState.customState() is the normal entry point if you're using a custom state file")
+      static DatawireState customState(String path) {
+        DatawireState dwState = new DatawireState();
+
+        dwState.load(path);
+
+        return dwState;
+      }
+
+      DatawireState() {
+        self._initialized = false;
+        self.runtime = concurrent.Context.runtime();
+      }
+
+      void load(String jsonInput) {
+        JSONObject obj = jsonInput.parseJSON();
+
+        if (!obj.isDefined()) {
+          self.runtime.fail("DatawireState: Invalid JSON, cannot load");
+        }
+
+        JSONObject orgs = obj["orgs"];
+
+        if (!orgs.isDefined()) {
+          self.runtime.fail("DatawireState: no orgs present in input JSON!");
+        }
+
+        self.object = obj;
+        self.orgs = orgs;
+
+        obj = self.object["orgID"];
+
+        if (!obj.isDefined()) {
+          self.runtime.fail("DatawireState: no default org ID present in input JSON!");
+        }
+
+        if (!obj.isString()) {
+          self.runtime.fail("DatawireState: default org ID in input JSON is not a string!");
+        }
+
+        self._defaultOrgID = obj.getString();
+
+        obj = self.orgs[self._defaultOrgID];
+
+        if (!obj.isDefined()) {
+          self.runtime.fail("DatawireState: default org ID in input JSON is invalid!");
+        }
+
+        self._defaultOrg = obj;
+
+        // Do switchToOrg by hand, since we're not initialized yet.
+        self._currentOrgID = self._defaultOrgID;
+        self._currentOrg = self._defaultOrg;
+
+        self._initialized = true;
+      }
+
+      void switchToOrg(String orgID) {
+        // If you add anything here, you'll need to revist the "Do switchToOrg by hand"
+        // comment above.
+
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        JSONObject org = self.orgs[orgID];
+
+        if (!org.isDefined()) {
+          self.runtime.fail("DatawireState: org " + orgID + " is not valid");
+        }
+
+        self._currentOrgID = orgID;
+        self._currentOrg = org;
+      }
+
+      String getDefaultOrgID() {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._defaultOrgID;
+      }
+
+      JSONObject getDefaultOrg() {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._defaultOrg;
+      }
+
+      String getCurrentOrgID() {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._currentOrgID;
+      }
+
+      JSONObject getCurrentOrg() {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._currentOrg;
+      }
+
+      String getCurrentEmail() {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._currentOrg["email"].getString();
+      }
+
+      List<String> getCurrentServices() {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._currentOrg["service_tokens"].keys();
+      }
+
+      String getCurrentServiceToken(String service_handle) {
+        if (!self._initialized) {
+          self.runtime.fail("DatawireState: call load() before attempting any operations");
+        }
+
+        return self._currentOrg["service_tokens"][service_handle].getString();
+      }
+
+      String stateContents(String path) {
+        return _datawire_fs.FS.fileContents(path);
+      }
+
+      String defaultStatePath() {
+        return _datawire_fs.FS.userHomeDir() + "/.datawire/datawire.json";
+      }
+
+      String defaultStateContents() {
+        return self.stateContents(self.defaultStatePath());
+      }
+
+      void loadDefaultState() {
+        self.load(self.defaultStateContents());
+      }
+    }
+  }
+
   namespace resolver {
     class DiscoClient extends client.CloudDiscoveryClient {
       BaseDiscoResolver resolver;

--- a/quark/io/datawire/quark/_datawire_fs_impl.java
+++ b/quark/io/datawire/quark/_datawire_fs_impl.java
@@ -1,0 +1,40 @@
+package io.datawire.quark.runtime;
+
+import io.datawire.quark.runtime.Runtime;
+import quark.concurrent.Context;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+public class _datawire_fs_impl {
+    public static String userHomeDir() {
+        return System.getProperty("user.home");
+    }
+
+    public static String fileContents(String path) {
+        String str = null;
+        Runtime runtime = Context.runtime();
+
+        try {
+            File file = new File(path);
+            FileInputStream fis = new FileInputStream(file);
+            byte[] data = new byte[(int) file.length()];
+
+            fis.read(data);
+            fis.close();
+
+            str = new String(data, "UTF-8");
+        }
+        catch (java.io.FileNotFoundException ex) {
+            runtime.fail("_datawire_fs.fileContents file not found: " + ex.getMessage());
+        }
+        catch (java.io.UnsupportedEncodingException ex) {
+            runtime.fail("_datawire_fs.fileContents unsupported encoding: " + ex.getMessage());
+        }
+        catch (java.io.IOException ex) {
+            runtime.fail("_datawire_fs.fileContents I/O error: " + ex.getMessage());
+        }
+
+        return str;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-# requirements for developing and/or testing quark and the runtime integrations
--e runtime/python-core
--e runtime/python-threaded
--e runtime/twisted
--e .
-pytest
-pexpect
+datawire-quark
+datawire-cloudtools
+nose

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>DWSTester</groupId>
+  <artifactId>TestDWState</artifactId>
+  <version>1.0.0</version>
+  <name>Datawire State Tester</name>
+
+  <properties>
+    <kotlin.version>1.0.0</kotlin.version>
+    <junit.version>4.10</junit.version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>datawire_connect_1_0_0</groupId>
+      <artifactId>datawire_connect_1_0_0</artifactId>
+      <version>0.0.1</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test-junit</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+
+        <configuration/>
+
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+<!-- 
+      What is this section supposed to be for exactly? mvn test runs the tests without it;
+      all it seems to do is mess things up.
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+
+        <configuration>
+          <mainClass>DWSTester.TestDWState</mainClass>
+        </configuration>
+      </plugin>
+ -->
+ 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+        <configuration>
+          <excludePackageNames>io.datawire:*.Functions</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test/src/test/kotlin/testDWState.kt
+++ b/test/src/test/kotlin/testDWState.kt
@@ -1,0 +1,61 @@
+package DWSTester
+
+import java.io.File
+import kotlin.test.*
+import org.junit.Test as test
+
+import datawire_connect.state.DatawireState
+
+class TestDWState {
+	@test fun check() {
+		val path: String = System.getProperty("GoldPath")
+
+		println("running check " + path)
+
+		val goldInfo = File(path).readLines()
+
+		var i: Int = 0
+
+		val goldDefaultPath = goldInfo[i++]
+		val goldOrgID = goldInfo[i++]
+		val goldEmail = goldInfo[i++]
+
+		println("goldDefaultPath " + goldDefaultPath)
+
+		val goldTokens: MutableMap<String, String> = hashMapOf()
+		val services: MutableSet<String> = mutableSetOf()
+
+		// Yeah, I know, this isn't terribly Kotlinesque. Cope. [ :) ]
+		goldInfo.takeLast(goldInfo.size - i).forEach {
+			val fields = it.split(":::")
+
+			val svcHandle = fields[0]
+			val svcToken = fields[1]
+
+			goldTokens[svcHandle] = svcToken
+			services.add(svcHandle)
+		}
+
+        var dwState = DatawireState();
+
+		assertEquals(dwState.defaultStatePath(), goldDefaultPath);
+
+        dwState = DatawireState.defaultState();
+
+		assertEquals(dwState.getCurrentOrgID(), goldOrgID);
+		assertEquals(dwState.getCurrentEmail(), goldEmail);
+
+		val goodTokens: Set<String> = 
+			services.fold(setOf(), 
+				          { acc, it -> 
+				          	if (goldTokens[it] == dwState.getCurrentServiceToken(it)) 
+				          	    acc + it
+				          	else
+				          	    acc })
+
+		val dwStateServices: Set<String> = dwState.getCurrentServices().toSet()
+
+		assertEquals(goodTokens, services)
+		assertEquals(goodTokens, dwStateServices)
+	}
+}

--- a/test/testDWState.js
+++ b/test/testDWState.js
@@ -1,0 +1,57 @@
+var process = require('process');
+var fs = require('fs');
+var assert = require('assert');
+
+var datawire_connect = require('datawire_connect_1_0_0').datawire_connect;
+var DatawireState = datawire_connect.state.DatawireState;
+
+var args = process.argv.splice(process.execArgv.length + 2);
+
+var goldInfo = fs.readFileSync(args[0]).toString().split("\n");
+
+var i = 0;
+
+var goldDefaultPath = goldInfo[i++];
+var goldOrgID = goldInfo[i++];
+var goldEmail = goldInfo[i++];
+var goldTokens = {};
+var services = [];
+
+while (i < goldInfo.length) {
+	if (goldInfo[i].length > 0) {
+		var tokenInfo = goldInfo[i].split(':::');
+
+		var svcHandle = tokenInfo[0];
+		var svcToken = tokenInfo[1];
+
+		goldTokens[svcHandle] = svcToken;
+		services.push(svcHandle);
+	}
+
+	i++;
+}
+
+var dwState = new DatawireState();
+
+assert.equal(dwState.defaultStatePath(), goldDefaultPath);
+
+dwState = DatawireState.defaultState();
+
+assert.equal(dwState.getCurrentOrgID(), goldOrgID);
+assert.equal(dwState.getCurrentEmail(), goldEmail);
+
+var delSvc = [];
+
+for (var i = 0; i < services.length; i++) {
+	var svcHandle = services[i];
+	var svcToken = dwState.getCurrentServiceToken(svcHandle);
+
+	assert.equal(svcToken, goldTokens[svcHandle]);
+	delSvc.push(svcHandle);
+}
+
+for (var i = 0; i < delSvc.length; i++) {
+	delete(goldTokens[delSvc[i]]);
+}
+
+assert.equal(Object.keys(goldTokens).length, 0);

--- a/test/testDWState.py
+++ b/test/testDWState.py
@@ -1,0 +1,59 @@
+#!python
+
+import os
+
+import json
+
+from datawire_connect.state import DatawireState as qDWState
+from datawire.utils.state import DataWireState as pDWState
+
+def jsonify(obj):
+  return json.dumps(obj, indent=4, separators=(',',':'), sort_keys=True)
+
+class TestQuarkDWState (object):
+  def test_defaultStatePath(self):
+    qState = qDWState()
+    pState = pDWState()
+
+    mDefaultPath = os.path.join(os.path.expanduser('~'), '.datawire', 'datawire.json')
+    pDefaultPath = pState.state_path
+
+    assert(qState.defaultStatePath() == mDefaultPath)
+    assert(pDefaultPath == mDefaultPath)
+
+  def test_contents(self):
+    pState = pDWState()
+
+    pJSON = pState.toJSON()
+
+    qState = qDWState()
+    qContents = qState.defaultStateContents()
+    qJSON = jsonify(json.loads(qContents))
+
+    assert(pJSON == qJSON)
+
+  def test_loadState(self):
+    pState = pDWState()
+
+    qState = qDWState.defaultState()
+
+    assert(qState.getCurrentOrgID() == pState.currentOrgID())
+    assert(qState.getCurrentEmail() == pState.currentOrg()['email'])
+
+    pSvcs = pState.currentOrg()['service_tokens'].keys()
+    qSvcs = qState.getCurrentServices()
+
+    assert(jsonify(qSvcs) == jsonify(pSvcs))
+
+    for svc in qSvcs:
+      assert(qState.getCurrentServiceToken(svc) == pState.currentServiceToken(svc))
+
+if __name__ == '__main__':
+    qState = qDWState.defaultState()
+
+    print("%s" % qState.defaultStatePath()) 
+    print("%s" % qState.getCurrentOrgID())
+    print("%s" % qState.getCurrentEmail())
+
+    for svc in qState.getCurrentServices():
+        print("%s:::%s" % (svc, qState.getCurrentServiceToken(svc)))


### PR DESCRIPTION
The Datawire Connect state (managed by the `dwc` command from `datawire-cloudtools`) notably includes the service tokens needed to easily use Cloud Discovery. Making it accessible from Quark makes it simpler to use from any supported target language.
